### PR TITLE
Fix MQTT password file recreation on restart

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -12,6 +12,7 @@ ensure_line() {
 }
 
 if [ -n "${MQTT_USER:-}" ] && [ -n "${MQTT_PASS:-}" ]; then
+    rm -f "$PASSWORD_FILE"
     mosquitto_passwd -b -c "$PASSWORD_FILE" "$MQTT_USER" "$MQTT_PASS"
     ensure_line "allow_anonymous false"
     ensure_line "password_file ${PASSWORD_FILE}"


### PR DESCRIPTION
This fixes the MQTT container crash on Railway persistent volumes.

Problem:
The entrypoint recreated /mosquitto/config/passwordfile with `mosquitto_passwd -c` on every start. Because the password file already existed on the mounted volume, the broker crashed with:
Error: Unable to open file /mosquitto/config/passwordfile for writing. File exists.

Fix:
Delete the old password file before recreating it during startup.
