### PR TITLE
docs: add architecture diagram to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ Deploy MQTT on railway.app with a single click.
 * Timezone Support (Set timezone in environment variables)
 * Railway config as code via `railway.toml`
 
+## 🏗️ Architecture
+
+```mermaid
+flowchart LR
+    Client(["📡 MQTT Client"]) -->|"MQTT / TCP"| Proxy["Railway TCP Proxy"]
+    Proxy -->|"$PORT → 1883"| Entry["docker-entrypoint.sh"]
+    Entry --> App["Container\neclipse-mosquitto"]
+    App --> Volume[("Volume\n/mosquitto/data")]
+```
+
 ## 🐍 How to Deploy
 
 1. Click Deploy on Railway and setup your credentials in the environment variables


### PR DESCRIPTION
## Summary
- Adds a Mermaid diagram to the README showing this template's deployed architecture: MQTT client → Railway TCP proxy → custom entrypoint → container (eclipse-mosquitto) → persistent volume.
- No functional changes.

## Test plan
- [x] Verified the Mermaid block renders (fenced ```mermaid, GitHub-native rendering).


---
_Generated by [Claude Code](https://claude.ai/code/session_01WwCVWpdDxXTCW5fYFbyCRw)_