### PR TITLE
fix: correct LICENSE copyright holder

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 TTN Leipzig
+Copyright (c) 2023 André Lademann
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- Found via an org-wide license audit across all `railwayapp-*` templates.
- The LICENSE listed `TTN Leipzig` as copyright holder — an unrelated organization (a meetup group), not the actual owner of this personal Railway template repo. Corrected to `André Lademann`.
- No functional changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WwCVWpdDxXTCW5fYFbyCRw)_